### PR TITLE
Don't close health monitor alerts on heartbeat.

### DIFF
--- a/jobs/riemann/templates/config/health_monitor.clj.erb
+++ b/jobs/riemann/templates/config/health_monitor.clj.erb
@@ -4,11 +4,6 @@
   (info "Setting up health monitor alerts")
 
   (where
-    (service "bosh.hm")
-    (changed-state {:init "ok"}
-      (where
-        (state "ok") (:resolve pd)
-          (else (where (state "critical") (:trigger pd)))
-          (else (where (state "warn") #(warn %))))))
-
+    (and (service "bosh.hm") (state "alert"))
+    (:trigger pd))
 )


### PR DESCRIPTION
Because health monitor alerts describe jobs and health monitor
heartbeats describe VMs, we shouldn't close an alert when a heartbeat
from the same VM is received.
