### PR TITLE
Page when elastic is critical.

### DIFF
--- a/jobs/riemann/spec
+++ b/jobs/riemann/spec
@@ -10,6 +10,7 @@ templates:
    config/pagerduty.clj.erb: include/pagerduty.clj
    config/expire.clj.erb: include/expire.clj
    config/health_monitor.clj.erb: include/health_monitor.clj
+   config/elastic.clj.erb: include/elastic.clj
    config/clamav.clj.erb: include/clamav.clj
    config/snort.clj.erb: include/snort.clj
    config/disk.clj.erb: include/disk.clj

--- a/jobs/riemann/templates/config/elastic.clj.erb
+++ b/jobs/riemann/templates/config/elastic.clj.erb
@@ -1,0 +1,12 @@
+(info "Loading elastic alerts")
+
+(defn elastic-alerts [pd]
+  (info "Setting up elastic alerts")
+
+  (where
+    (service "elasticsearch health")
+      (changed-state {:init "ok"}
+        (where (state "critical") (:trigger pd)
+          (else (where (state "ok") (:resolve pd)))
+          (else (where (state "warning") #(warn %))))))
+)

--- a/jobs/riemann/templates/config/riemann.config.erb
+++ b/jobs/riemann/templates/config/riemann.config.erb
@@ -7,6 +7,7 @@
 (include "/var/vcap/jobs/riemann/include/logging.clj")
 (include "/var/vcap/jobs/riemann/include/pagerduty.clj")
 (include "/var/vcap/jobs/riemann/include/health_monitor.clj")
+(include "/var/vcap/jobs/riemann/include/elastic.clj")
 (include "/var/vcap/jobs/riemann/include/clamav.clj")
 (include "/var/vcap/jobs/riemann/include/snort.clj")
 (include "/var/vcap/jobs/riemann/include/disk.clj")
@@ -18,6 +19,7 @@
    (default :ttl 60
      index
      (hm-alerts pd)
+     (elastic-alerts pd)
      (clamav-alerts pd)
      (snort-alerts pd)
      (disk-alerts pd)


### PR DESCRIPTION
See https://github.com/riemann/riemann-tools/blob/master/tools/riemann-elasticsearch/bin/riemann-elasticsearch for alert messages.

Requires https://github.com/18F/cg-deploy-logsearch/pull/13 for messages to get pushed to riemann.
