### PR TITLE
Update pagerduty arguments.

### DIFF
--- a/jobs/riemann/templates/config/pagerduty.clj.erb
+++ b/jobs/riemann/templates/config/pagerduty.clj.erb
@@ -1,2 +1,2 @@
 (info "Loading pagerduty integration")
-(def pd (pagerduty "<%= p("riemann.pagerduty_api_key") %>"))
+(def pd (pagerduty { :service-key "<%= p("riemann.pagerduty_api_key") %>" }))


### PR DESCRIPTION
Because riemann changed the signature of the pagerduty adapter in the latest release.

@sharms 
