### PR TITLE
Pass firehose tag fields.

### DIFF
--- a/jobs/riemann/templates/config/influxdb.clj.erb
+++ b/jobs/riemann/templates/config/influxdb.clj.erb
@@ -3,7 +3,7 @@
                       :username "<%= p("riemann.influxdb.username") %>"
                       :password "<%= p("riemann.influxdb.password") %>"
                       :db "<%= p("riemann.influxdb.database") %>"
-		      :version :<%= p("riemann.influxdb.version") %>})
+                      :version :<%= p("riemann.influxdb.version") %>})
 
 (defn influx [opts]
   (batch 1000 30

--- a/jobs/riemann/templates/config/riemann.config.erb
+++ b/jobs/riemann/templates/config/riemann.config.erb
@@ -54,5 +54,8 @@
      (snort-alerts pd)
      (disk-alerts pd)
      (swap-alerts pd)
-     (influx {:tags {"env" "<%= p("riemann.influxdb.database") %>"}})
+
+     ; Send events to influxdb with firehose attributes as tags
+     (influx {:tags {"env" "<%= p("riemann.influxdb.database") %>"}
+              :tag-fields #{:host :deployment :job :index :ip}})
 )))


### PR DESCRIPTION
Pass firehose attributes as tags rather than fields in influxdb so that
queries will continue to work.
