### PR TITLE
Alert on overall job health rather than specific alerts

### DIFF
--- a/jobs/riemann/templates/config/health_monitor.clj.erb
+++ b/jobs/riemann/templates/config/health_monitor.clj.erb
@@ -1,9 +1,27 @@
 (info "Loading health monitor alerts")
 
+(defn rewrite-bosh-hm-events []
+  (where (service "bosh.hm")
+    ; rewrite bosh.hm events so state = job_state, service = service.name, host = deployment.job.index
+    (smap #(assoc % :state (:job_state %) :service (str (:service %) "." (:name %)) :host (str (:deployment %) "." (:job %) "." (:index %)))
+      #(reinject %)
+    )
+  )
+)
+
 (defn hm-alerts [pd]
   (info "Setting up health monitor alerts")
-  (try
-    (where
-      (and (service "bosh.hm") (state "alert"))
-      (:trigger pd))
-  (catch Exception e #(warn "clamav-exception: " (.getMessage e)))))
+  (where (service "bosh.hm.system.healthy")
+    (changed-state {:init "running"}
+      (stable 180 :state
+        (where (state "failing")
+          #(warn %)
+          (:trigger pd)
+        (else
+          #(info %)
+          (:resolve pd)
+        ))
+      )
+    )
+  )
+)

--- a/jobs/riemann/templates/config/riemann.config.erb
+++ b/jobs/riemann/templates/config/riemann.config.erb
@@ -29,6 +29,8 @@
   (streams
    (default :ttl 60
      index
+
+     (rewrite-bosh-hm-events)
      (hm-alerts pd)
 
      <% if_p("riemann.logsearch.platform_logs_threshold", "riemann.logsearch.app_logs_threshold") do %>


### PR DESCRIPTION
@jmcarp @sharms WDYT about alerting on overall job health, rather than any time `state` goes to `alert` as I'd really like PagerDuty not to go off everytime bosh restarts a service during a deployment.


## Hey Bosh:
![image](https://cloud.githubusercontent.com/assets/604163/20356336/16159946-abd9-11e6-83e2-4133a68aeda2.png)


