### PR TITLE
Simplify elastic alert.

### DIFF
--- a/jobs/riemann/templates/config/elastic.clj.erb
+++ b/jobs/riemann/templates/config/elastic.clj.erb
@@ -3,20 +3,12 @@
 (defn elastic-alerts [pd]
   (info "Setting up elastic alerts")
 
-  (try
-    (where (and (service "elasticsearch health") (not (expired? event)))
-      (moving-time-window 60
-        (smap (fn [events]
-          (let [ratio (/ (count (filter #(= "ok" (:state %)) events))
-                         (count events))]
-            (event {:service "elasticsearch health window"
-                    :metric  ratio
-                    :state   (condp > ratio
-                              0.9 "critical"
-                              1.0 "warning"
-                                  "ok")})))
-          (changed-state {:init "ok"}
-            (where (state "ok") (:resolve pd)
-              (else (where (state "warning") #(warn %)))
-              (else (where (state "critical") (:trigger pd))))))))
-    (catch Exception e #(warn "elastic-exception: " (.getMessage e)))))
+  (where (service "elasticsearch health")
+    (changed-state {:init "ok"}
+      (stable 180 :state
+        (where (state "critical")
+          (with :description "https://cloud.gov/docs/ops/runbook/troubleshooting-logsearch"
+            (:trigger pd))
+        (else
+          (:resolve pd))))))
+)


### PR DESCRIPTION
* Drop confusing health ratios in favor of `stable`
* Link to troubleshooting docs

h/t @cnelson 