### PR TITLE
Alert on non-ok elastic status.

### DIFF
--- a/jobs/riemann/templates/config/elastic.clj.erb
+++ b/jobs/riemann/templates/config/elastic.clj.erb
@@ -6,9 +6,9 @@
   (where (service "elasticsearch health")
     (changed-state {:init "ok"}
       (stable 180 :state
-        (where (state "critical")
-          (with :description "https://cloud.gov/docs/ops/runbook/troubleshooting-logsearch"
-            (:trigger pd))
+        (where (state "ok")
+          (:resolve pd)
         (else
-          (:resolve pd))))))
+          (with :description "https://cloud.gov/docs/ops/runbook/troubleshooting-logsearch"
+            (:trigger pd)))))))
 )


### PR DESCRIPTION
Rejigger elastic alert logic so that both critical and expired states
trigger an alert.

With this in place, we'll get alerted if our elastic monitoring script stops working, like it did recently due to https://github.com/riemann/riemann-tools/issues/166.

Want to validate this with me this week @rogeruiz ?