### PR TITLE
expose option to enable hprof dumps when OutOfMemory exceptions occur

### DIFF
--- a/jobs/riemann/spec
+++ b/jobs/riemann/spec
@@ -48,6 +48,9 @@ properties:
     description: "Specifies the initial size of the memory allocation pool"
   riemann.java.xmx:
     description: "Specifies the maximum size of the memory allocation pool"
+  riemann.java.HeapDumpPath:
+    description: "If not blank will write heap dumps to this directory when OutOfMemory exceptions occur"
+    default: "/var/vcap/store/riemann"
   riemann.custom_rules:
     description: "Custom alert rules"
     default: ""

--- a/jobs/riemann/templates/bin/riemann_ctl
+++ b/jobs/riemann/templates/bin/riemann_ctl
@@ -14,6 +14,7 @@ export LANG=en_US.UTF-8
 JAVA_OPTS="-Dio.netty.tmpdir=$TMP_DIR -server -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSParallelRemarkEnabled -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -XX:+UseCompressedOops -XX:+CMSClassUnloadingEnabled"
 <% if_p("riemann.java.xms") do %>JAVA_OPTS="$JAVA_OPTS -Xms<%= p("riemann.java.xms") %>"<% end %>
 <% if_p("riemann.java.xmx") do %>JAVA_OPTS="$JAVA_OPTS -Xmx<%= p("riemann.java.xmx") %>"<% end %>
+<% if_p("riemann.java.HeapDumpPath") do %>JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=<%= p("riemann.java.HeapDumpPath") %> -XX:+HeapDumpOnOutOfMemoryError"<% end %>
 
 case $1 in
   start)


### PR DESCRIPTION
So next time riemann runs out of memory we can actually figure out why.
