### PR TITLE
Alert on memory utilization

### DIFF
--- a/jobs/riemann/spec
+++ b/jobs/riemann/spec
@@ -119,7 +119,7 @@ properties:
     description: "Array of hashes describing host specific overrides for memory utilization percentage alerts"
     default: []
     # The following keys MUST EXIST in each hash:
-    # host: A regex which must match the host(s) this override should apply to
+    # host: A regex which must match the host(s) this override should apply to.  The regex must match the entire host, partial matches are not allowed.
     # threshold: A metric value above this threshold will trigger a state change
     # state: A state to change to:
     #   "critical" - An alert is raised via PagerDuty

--- a/jobs/riemann/spec
+++ b/jobs/riemann/spec
@@ -107,13 +107,32 @@ properties:
     description: "Warn when swap utilization percentage is >="
     default: 10
 
-  # Memory alert settings
+  # Default Memory alert settings applied to all hosts unless they are specifically overrided below
   riemann.memory.critical:
     description: "Raise an alert when memory utilization percentage is >="
-    default: 85
+    default: 90
   riemann.memory.warn:
     description: "Warn when memory utilization percentage is >="
     default: 75
+
+  riemann.memory.overrides:
+    description: "Array of hashes describing host specific overrides for memory utilization percentage alerts"
+    default: []
+    # The following keys MUST EXIST in each hash:
+    # host: A regex which must match the host(s) this override should apply to
+    # threshold: A metric value above this threshold will trigger a state change
+    # state: A state to change to:
+    #   "critical" - An alert is raised via PagerDuty
+    #   "warn" - A notification is generated
+    #   "ok" - Open alerts are closed
+    # NOTE: This is implemented using https://clojuredocs.org/clojure.core/cond so order of entries in this list is important!
+    example:
+    - host: '^queue.\d+'
+      threshold: 50
+      state: critical
+    - host: '^queue.\d+'
+      threshold: 25
+      state: warn
 
   riemann.logsearch.platform_logs_threshold:
     description: "Minimum number of platform logs per interval"

--- a/jobs/riemann/spec
+++ b/jobs/riemann/spec
@@ -19,6 +19,7 @@ templates:
   config/snort.clj.erb: include/snort.clj
   config/disk.clj.erb: include/disk.clj
   config/swap.clj.erb: include/swap.clj
+  config/memory.clj.erb: include/memory.clj
   config/logging.clj.erb: include/logging.clj
   config/logsearch.clj.erb: include/logsearch.clj
   config/interface.clj.erb: include/interface.clj
@@ -100,11 +101,19 @@ properties:
 
   # Swap alert settings
   riemann.swap.critical:
-    description: "Amount of swap in bits remaining before alerting"
-    default: 1000000000
+    description: "Raise an alert when swap utilization percentage is >="
+    default: 25
   riemann.swap.warn:
-    description: "Amount of swap in bits remaining before warning"
-    default: 5000000000
+    description: "Warn when swap utilization percentage is >="
+    default: 10
+
+  # Memory alert settings
+  riemann.memory.critical:
+    description: "Raise an alert when memory utilization percentage is >="
+    default: 85
+  riemann.memory.warn:
+    description: "Warn when memory utilization percentage is >="
+    default: 75
 
   riemann.logsearch.platform_logs_threshold:
     description: "Minimum number of platform logs per interval"

--- a/jobs/riemann/templates/config/memory.clj.erb
+++ b/jobs/riemann/templates/config/memory.clj.erb
@@ -1,0 +1,19 @@
+(info "Loading memory alerts")
+
+(defn memory-alerts [pd]
+  (info "Setting up memory alerts")
+  (where (service "memory/percent-used")
+    (pipe -
+      (splitp < metric
+        <%= p("riemann.memory.critical") %> (with :state "critical" -)
+        <%= p("riemann.memory.warn") %> (with :state "warn" -)
+        (with :state "ok" -)
+      )
+      (changed-state {:init "ok"} (
+        where (state "ok") (:resolve pd)
+        (else (where (state "critical") (:trigger pd)
+        (else (where (state "warn") #(warn "Free memory is low: " %)
+      ))))))
+    )
+  )
+)

--- a/jobs/riemann/templates/config/memory.clj.erb
+++ b/jobs/riemann/templates/config/memory.clj.erb
@@ -3,17 +3,29 @@
 (defn memory-alerts [pd]
   (info "Setting up memory alerts")
   (where (service "memory/percent-used")
-    (pipe -
-      (splitp < metric
-        <%= p("riemann.memory.critical") %> (with :state "critical" -)
-        <%= p("riemann.memory.warn") %> (with :state "warn" -)
-        (with :state "ok" -)
+    (smap
+      (fn [event]
+        ; set the event's state based on the value of the metric, and possibly the specific host it originated from
+        (assoc event :state
+          (cond
+          <% p("riemann.memory.overrides").each do |over| %>
+            (and (re-matches #"<%= over["host"] %>" (:host event)) (> (:metric event) <%= over["threshold"] %>)) "<%= over["state"] %>"
+          <% end %>
+            (> (:metric event) <%= p("riemann.memory.critical") %>) "critical"
+            (> (:metric event) <%= p("riemann.memory.warn") %>) "warn"
+            :else "ok"
+          )
+        )
       )
-      (changed-state {:init "ok"} (
-        where (state "ok") (:resolve pd)
-        (else (where (state "critical") (:trigger pd)
-        (else (where (state "warn") #(warn "Free memory is low: " %)
-      ))))))
+
+      ; only act on state changes when they've been stable for 5 minutes
+      (stable 300 :state
+        (changed-state {:init "ok"} (
+          where (state "ok") (:resolve pd)
+          (else (where (state "critical") (:trigger pd)
+          (else (where (state "warn") #(warn "Free memory is low: " %)
+        ))))))
+      )
     )
   )
 )

--- a/jobs/riemann/templates/config/riemann.config.erb
+++ b/jobs/riemann/templates/config/riemann.config.erb
@@ -30,6 +30,7 @@
 (include "/var/vcap/jobs/riemann/include/snort.clj")
 (include "/var/vcap/jobs/riemann/include/disk.clj")
 (include "/var/vcap/jobs/riemann/include/swap.clj")
+(include "/var/vcap/jobs/riemann/include/memory.clj")
 (include "/var/vcap/jobs/riemann/include/influxdb.clj")
 (include "/var/vcap/jobs/riemann/include/influxdb_backups.clj")
 (include "/var/vcap/jobs/riemann/include/awslogs.clj")
@@ -70,6 +71,7 @@
      (snort-alerts pd)
      (disk-alerts pd)
      (swap-alerts pd)
+     (memory-alerts pd)
 
      (unknown-vm-alert pd)
 


### PR DESCRIPTION
I wasn't sure what to do about the thresholds for this alert as for the logsearch queue, I wanted them to be low enough that we'd have time to respond before redis goes OOM so ideally we'd have our alert threshold set much lower (50%? 75?) but for many of our other instances it's a good thing (efficient use of our IaaS resources) if they are sitting around 85-90% memory utilization and I didn't want to trigger false positives for all of those cases.

I could extend this alert to have specific lower thresholds for queue instances WDYT?

cc: https://github.com/18F/cg-atlas/issues/196