### PR TITLE
Update app index names in checklogs job

### DIFF
--- a/jobs/riemann-checklogs/templates/bin/check-logs.sh
+++ b/jobs/riemann-checklogs/templates/bin/check-logs.sh
@@ -29,5 +29,5 @@ QUERY=$(${JQ_PATH} -n "{
 PLATFORM_LOGS=$(( $(query "platform" ${TODAY}) + $(query "platform" ${YESTERDAY}) ))
 ${RIEMANNC_PATH} --service "logsearch.health.platform" --host $(hostname) --ttl ${TTL} --metric_sint64 ${PLATFORM_LOGS}
 
-APP_LOGS=$(( $(query "app-*" ${TODAY}) + $(query "app-*" ${YESTERDAY}) ))
+APP_LOGS=$(( $(query "app" ${TODAY}) + $(query "app" ${YESTERDAY}) ))
 ${RIEMANNC_PATH} --service "logsearch.health.app" --host $(hostname) --ttl ${TTL} --metric_sint64 ${APP_LOGS}


### PR DESCRIPTION
This check was raising false positive alerts since we switched back to index-per-day.