### PR TITLE
Configure elastic stable dt.

### DIFF
--- a/jobs/riemann/spec
+++ b/jobs/riemann/spec
@@ -163,6 +163,10 @@ properties:
     - service: awslogs._GLOBAL
       threshold: 300
 
+  riemann.elastic.stable_dt:
+    description: "Elastic stable delta time threshold"
+    default: 300
+
   # "fail closed" settings
   # https://github.com/18F/cg-product/issues/476
   riemann.nologs.uptime:

--- a/jobs/riemann/templates/config/elastic.clj.erb
+++ b/jobs/riemann/templates/config/elastic.clj.erb
@@ -1,11 +1,11 @@
 (info "Loading elastic alerts")
 
-(defn elastic-alerts [pd]
+(defn elastic-alerts [pd stable-dt]
   (info "Setting up elastic alerts")
 
   (where (service "elasticsearch health")
     (changed-state {:init "ok"}
-      (stable 180 :state
+      (stable stable-dt :state
         (where (state "ok")
           (:resolve pd)
         (else

--- a/jobs/riemann/templates/config/riemann.config.erb
+++ b/jobs/riemann/templates/config/riemann.config.erb
@@ -60,7 +60,7 @@
      (awslogs-alerts pd)
      <% end %>
 
-     (elastic-alerts pd)
+     (elastic-alerts pd <%= p ("riemann.elastic.stable_dt") %>)
 
      <% if_p("riemann.rds.cpu_threshold") do %>
      (rds-alerts pd)


### PR DESCRIPTION
h/t @cnelson

Default stable dt corresponds to https://github.com/cloudfoundry-community/logsearch-boshrelease/pull/39.