### PR TITLE
Different thresholds for critical and non-critical elastic alerts

### DIFF
--- a/jobs/riemann/spec
+++ b/jobs/riemann/spec
@@ -163,9 +163,13 @@ properties:
     - service: awslogs._GLOBAL
       threshold: 300
 
-  riemann.elastic.stable_dt:
-    description: "Elastic stable delta time threshold"
-    default: 300
+  riemann.elastic.stable_critical:
+    description: "When riemann emitter reports critical state for this many seconds, raise an alert.  This should be shorter than rieman.elastic.stable_other"
+    default: 60
+
+  riemann.elastic.stable_other:
+    description: "When riemann emitter reports any state other than critical for this many seconds, trigger an action (alert or resolution)"
+    default: 900
 
   # "fail closed" settings
   # https://github.com/18F/cg-product/issues/476

--- a/jobs/riemann/templates/config/elastic.clj.erb
+++ b/jobs/riemann/templates/config/elastic.clj.erb
@@ -1,14 +1,29 @@
 (info "Loading elastic alerts")
 
-(defn elastic-alerts [pd stable-dt]
+(defn elastic-alerts [pd stable-other stable-critical]
   (info "Setting up elastic alerts")
 
   (where (service "elasticsearch health")
-    (changed-state {:init "ok"}
-      (stable stable-dt :state
-        (where (state "ok")
-          (:resolve pd)
-        (else
-          (with :description "https://cloud.gov/docs/ops/runbook/troubleshooting-logsearch"
-            (:trigger pd)))))))
+    (with :description "https://cloud.gov/docs/ops/runbook/troubleshooting-logsearch"
+      (changed-state {:init "ok"}
+        (sdo
+          ; Trigger critical alerts faster than other states as the cluster should never be red
+          (stable stable-critical :state
+            (where (state "critical")
+              (:trigger pd)
+            )
+          )
+          ; Make sure the cluster is either in a yellow state for a long time before we raise an alrt
+          ; Or that it remains green for the same period of time before closing it
+          (stable stable-other :state
+            (where (state "ok")
+              (:resolve pd)
+            (else
+              (:trigger pd)
+            ))
+          )
+        )
+      )
+    )
+  )
 )

--- a/jobs/riemann/templates/config/riemann.config.erb
+++ b/jobs/riemann/templates/config/riemann.config.erb
@@ -60,7 +60,7 @@
      (awslogs-alerts pd)
      <% end %>
 
-     (elastic-alerts pd <%= p ("riemann.elastic.stable_dt") %>)
+     (elastic-alerts pd <%= p("riemann.elastic.stable_other") %> <%= p("riemann.elastic.stable_critical") %>)
 
      <% if_p("riemann.rds.cpu_threshold") do %>
      (rds-alerts pd)


### PR DESCRIPTION
because elastic alerts should tolerate the cluster being yellow longer than it does red.

@jmcarp WDYT?