### PR TITLE
Handle expired k8s containers

### DIFF
--- a/jobs/riemann/templates/config/k8s.clj.erb
+++ b/jobs/riemann/templates/config/k8s.clj.erb
@@ -4,7 +4,7 @@
       (with :description "https://cloud.gov/docs/ops/runbook/troubleshooting-kubernetes"
         (stable stable-time :state
           (changed-state {:init "Running"}
-            (where (state "Running")
+            (where (or (state "Running") (state "expired"))
               (:resolve pd)
             (else
               (:trigger pd)


### PR DESCRIPTION
It's ok for podstatus messages to expire as pods come and go as they move around the cluster.

